### PR TITLE
Bring back disabled console command

### DIFF
--- a/QMultiMod/Patches/InventoryConsoleCommands_Awake_Patch.cs
+++ b/QMultiMod/Patches/InventoryConsoleCommands_Awake_Patch.cs
@@ -1,0 +1,14 @@
+using Harmony;
+
+namespace QMultiMod.Patches
+{
+    [HarmonyPatch(typeof(InventoryConsoleCommands))]
+    [HarmonyPatch("Awake")]
+    class InventoryConsoleCommands_Awake_Patch
+    {
+        public static void Postfix(InventoryConsoleCommands __instance)
+        {
+            DevConsole.RegisterConsoleCommand(__instance, "resizestorage"); ;
+        }
+    }
+}


### PR DESCRIPTION
So actually, as I'm sure you know, the devs has diabled some console commands, but the actuall functions is there, so... We can simply register it back.
This is awsome command that allows players to change the size of the sotrage they has opened right now to anything they want (yes, even 1000 1000)
Syntax is: resizestorage width height
works while the storage is opened =)